### PR TITLE
adapt to documents backend changes

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -15,13 +15,15 @@ import staticNewsletters from '../src/data/newsletters'
 
 const getDocuments = gql`
   query getDocuments {
-    documents {
-      meta {
-        slug
-        title
-        description
-        image
-        publishDate
+    documents(first: 2) {
+      nodes {
+        meta {
+          slug
+          title
+          description
+          image
+          publishDate
+        }
       }
     }
   }
@@ -40,7 +42,7 @@ class Index extends Component {
 
     let newsletters = loading || !documents
       ? []
-      : documents.concat(staticNewsletters)
+      : documents.nodes.concat(staticNewsletters)
 
     return (
       <Layout meta={meta} url={url} cover={(

--- a/pages/news.js
+++ b/pages/news.js
@@ -14,12 +14,14 @@ import staticNewsletters from '../src/data/newsletters'
 const getDocuments = gql`
   query getDocuments {
     documents {
-      meta {
-        slug
-        title
-        description
-        image
-        publishDate
+      nodes {
+        meta {
+          slug
+          title
+          description
+          image
+          publishDate
+        }
       }
     }
   }
@@ -30,7 +32,7 @@ const News = (props) => {
 
   let newsletters = loading || !documents
     ? []
-    : documents.concat(staticNewsletters)
+    : documents.nodes.concat(staticNewsletters)
 
   const meta = {
     title: 'Aktuelles von Project R',


### PR DESCRIPTION
To be released with https://github.com/orbiting/publikator-backend/pull/22

backend now supports pagination resulting in a documents connection instead of an direct array