### PR TITLE
subscribe construction users to projectR interest ID of republik newsletters as well

### DIFF
--- a/server/newsletter.js
+++ b/server/newsletter.js
@@ -60,12 +60,15 @@ const subscribeEmail = (email) => {
     .digest('hex')
     .toLowerCase()
 
-  const { MAILCHIMP_INTEREST_ID, MAILCHIMP_INTEREST_ID_2 } = process.env
-  let interests = {}
-  // The original interest ID of construction subscribers.
-  !!MAILCHIMP_INTEREST_ID && (interests[MAILCHIMP_INTEREST_ID] = true)
-  // The interest ID of republik users subscribed to the construction newsletter.
-  !!MAILCHIMP_INTEREST_ID_2 && (interests[MAILCHIMP_INTEREST_ID_2] = true)
+  const { MAILCHIMP_INTEREST_IDS = '' } = process.env
+  const interestIds = MAILCHIMP_INTEREST_IDS.split(',').filter(Boolean)
+  const interests = interestIds.reduce(
+    (index, id) => {
+      index[id] = true
+      return index
+    },
+    {}
+  )
 
   return fetch(`https://us14.api.mailchimp.com/3.0/lists/${process.env.MAILCHIMP_LIST_ID}/members/${hash}`, {
     method: 'PUT',

--- a/server/newsletter.js
+++ b/server/newsletter.js
@@ -60,6 +60,13 @@ const subscribeEmail = (email) => {
     .digest('hex')
     .toLowerCase()
 
+  const { MAILCHIMP_INTEREST_ID, MAILCHIMP_INTEREST_ID_2 } = process.env
+  let interests = {}
+  // The original interest ID of construction subscribers.
+  !!MAILCHIMP_INTEREST_ID && (interests[MAILCHIMP_INTEREST_ID] = true)
+  // The interest ID of republik users subscribed to the construction newsletter.
+  !!MAILCHIMP_INTEREST_ID_2 && (interests[MAILCHIMP_INTEREST_ID_2] = true)
+
   return fetch(`https://us14.api.mailchimp.com/3.0/lists/${process.env.MAILCHIMP_LIST_ID}/members/${hash}`, {
     method: 'PUT',
     headers: {
@@ -69,9 +76,7 @@ const subscribeEmail = (email) => {
     body: JSON.stringify({
       email_address: email,
       status: 'subscribed',
-      interests: process.env.MAILCHIMP_INTEREST_ID && {
-        [process.env.MAILCHIMP_INTEREST_ID]: true
-      }
+      interests: interests
     })
   })
     .then(response => response.json())


### PR DESCRIPTION
we decided to not just replace the original interest ID, because we might want to separately target users which signed up on construction in the future.

open for naming changes of the env variables.